### PR TITLE
Adding RegisterScreen without user input validation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,4 +101,7 @@ dependencies {
 
     // Allow use of java.time.Instant below API 26
     coreLibraryDesugaring(libs.desugar.jdk.libs)
+
+    // Extend compose system pieces
+    implementation(libs.androidx.compose.foundation)
 }

--- a/app/src/main/java/com/jvoye/tasky/MainActivity.kt
+++ b/app/src/main/java/com/jvoye/tasky/MainActivity.kt
@@ -14,18 +14,29 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.jvoye.tasky.auth.presentation.register.RegisterScreenRoot
+import com.jvoye.tasky.auth.presentation.register.RegisterState
 import com.jvoye.tasky.core.presentation.designsystem.buttons.TaskyDeleteButton
 import com.jvoye.tasky.core.presentation.designsystem.buttons.TaskyFilledButton
 import com.jvoye.tasky.core.presentation.designsystem.buttons.TaskyFloatingActionButton
 import com.jvoye.tasky.core.presentation.designsystem.buttons.TaskyOutlinedButton
+import com.jvoye.tasky.core.presentation.designsystem.textfields.TaskyTextField
+import com.jvoye.tasky.core.presentation.designsystem.theme.Icon_Check
 import com.jvoye.tasky.core.presentation.designsystem.theme.TaskyTheme
 
 class MainActivity : ComponentActivity() {
@@ -34,88 +45,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TaskyTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    TaskyThemeTest(
-                        modifier = Modifier
-                            .padding(innerPadding)
-                    )
-                }
+                RegisterScreenRoot()
             }
         }
     }
-}
-
-
-// Composable for testing the Material Theme setup
-@Composable
-private fun TaskyThemeTest(modifier: Modifier = Modifier) {
-    Surface(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(300.dp)
-                    .background(MaterialTheme.colorScheme.surface)
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                TaskyOutlinedButton(
-                    text = stringResource(R.string.cancel),
-                    onClick = {},
-                    modifier = Modifier
-                        .weight(0.5f),
-                )
-
-                Spacer(modifier = Modifier.width(16.dp))
-
-                TaskyDeleteButton(
-                    text = stringResource(R.string.delete),
-                    onClick = {},
-                    isLoading = true,
-                    enabled = false,
-                    modifier = Modifier
-                        .weight(0.5f)
-                )
-            }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(150.dp)
-                    .background(MaterialTheme.colorScheme.surface)
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                TaskyFilledButton(
-                    text = stringResource(R.string.get_started),
-                    onClick = {},
-
-                )
-            }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(150.dp)
-                    .background(MaterialTheme.colorScheme.surface)
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                TaskyFloatingActionButton(
-                    onClick = {}
-                )
-            }
-
-        }
-    }
-
 }

--- a/app/src/main/java/com/jvoye/tasky/auth/domain/PasswordValidationState.kt
+++ b/app/src/main/java/com/jvoye/tasky/auth/domain/PasswordValidationState.kt
@@ -1,0 +1,11 @@
+package com.jvoye.tasky.auth.domain
+
+data class PasswordValidationState(
+    val hasMinLength: Boolean = false,
+    val hasNumber: Boolean = false,
+    val hasLowerCaseCharacter: Boolean = false,
+    val hasUpperCaseCharacter: Boolean = false
+) {
+    val isValidPassword: Boolean
+        get() = hasMinLength && hasNumber && hasLowerCaseCharacter && hasUpperCaseCharacter
+}

--- a/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterAction.kt
+++ b/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterAction.kt
@@ -1,0 +1,7 @@
+package com.jvoye.tasky.auth.presentation.register
+
+sealed interface RegisterAction {
+    data object OnTogglePasswordVisibilityClick: RegisterAction
+    data object OnGetStartedClick: RegisterAction
+    data object OnLoginClick: RegisterAction
+}

--- a/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterScreen.kt
+++ b/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterScreen.kt
@@ -1,0 +1,242 @@
+package com.jvoye.tasky.auth.presentation.register
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.jvoye.tasky.R
+import com.jvoye.tasky.core.presentation.designsystem.buttons.TaskyFilledButton
+import com.jvoye.tasky.core.presentation.designsystem.textfields.TaskyPasswordTextField
+import com.jvoye.tasky.core.presentation.designsystem.textfields.TaskyTextField
+import com.jvoye.tasky.core.presentation.designsystem.theme.Icon_Check
+import com.jvoye.tasky.core.presentation.designsystem.theme.TaskyTheme
+import com.jvoye.tasky.core.presentation.designsystem.theme.link
+
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.withLink
+import com.jvoye.tasky.core.presentation.designsystem.theme.surfaceHigher
+
+//import androidx.compose.foundation.text.appendLink
+
+@Composable
+fun RegisterScreenRoot(
+
+) {
+    val viewModel = viewModel<RegisterViewModel>()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    RegisterScreen(
+        state = state,
+        onAction = viewModel::onAction
+    )
+}
+
+@Composable
+private fun RegisterScreen(
+    state: RegisterState,
+    onAction: (RegisterAction) -> Unit
+) {
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentWindowInsets = WindowInsets.statusBars
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 40.dp, bottom = 36.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                RegistrationHeaderSection()
+            }
+            val rootModifier = Modifier
+                .fillMaxSize()
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 24.dp,
+                        topEnd = 24.dp
+                    )
+                )
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(
+                    horizontal = 16.dp,
+                    vertical = 28.dp
+                )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+
+            ) {
+                Column(
+                    modifier = rootModifier
+
+                ) {
+                    RegistrationFormSection(
+                        state = state,
+                        onAction = onAction
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    RegistrationButtonSection(
+                        onAction = onAction
+                    ) 
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegistrationHeaderSection() {
+    Text(
+        text = stringResource(R.string.create_your_account),
+        style = MaterialTheme.typography.headlineLarge
+    )
+}
+
+@Composable
+private fun RegistrationFormSection (
+    state: RegisterState,
+    onAction: (RegisterAction) -> Unit
+) {
+    Column(
+        modifier = Modifier
+    ) {
+        TaskyTextField(
+            state = state.name,
+            endIcon = if (state.isNameValid) {
+                Icon_Check
+            } else null,
+            borderColor = if (!state.isNameValid){
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.surfaceHigher
+            },
+            hint = stringResource(R.string.name),
+            modifier = Modifier.fillMaxWidth(),
+            keyboardType = KeyboardType.Text,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        TaskyTextField(
+            state = state.email,
+            endIcon = if (state.isEmailValid) {
+                Icon_Check
+            } else null,
+            borderColor = if (!state.isEmailValid){
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.surfaceHigher
+            },
+            hint = stringResource(R.string.email_address),
+            modifier = Modifier.fillMaxWidth(),
+            keyboardType = KeyboardType.Email,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        TaskyPasswordTextField(
+            state = state.password,
+            isPasswordVisible = state.isPasswordVisible,
+            onTogglePasswordVisibility = {
+                onAction(RegisterAction.OnTogglePasswordVisibilityClick)
+            },
+            hint = stringResource(R.string.password)
+        )
+    }
+}
+
+@Composable
+fun RegistrationButtonSection(
+    onAction: (RegisterAction) -> Unit
+) {
+    TaskyFilledButton(
+        text = stringResource(R.string.get_started),
+        onClick = { onAction(RegisterAction.OnGetStartedClick) }
+    )
+
+    Spacer(modifier = Modifier.height(20.dp))
+
+    val annotatedString = buildAnnotatedString {
+        withStyle(
+            style = SpanStyle(
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        ) {
+            append(stringResource(R.string.already_have_an_account) + " ")
+        }
+        withLink(
+            LinkAnnotation.Clickable(
+                tag = "Login_click",
+                linkInteractionListener = {
+                    onAction(RegisterAction.OnLoginClick)
+                }
+            )
+        ) {
+            withStyle(
+                style = SpanStyle(
+                    color = MaterialTheme.colorScheme.link
+                )
+            ) {
+                append(stringResource(R.string.login))
+            }
+        }
+    }
+
+    Text(
+        text = annotatedString,
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.fillMaxWidth(),
+        textAlign = TextAlign.Center
+    )
+}
+
+@Preview
+@Composable
+private fun RegisterScreenPreview() {
+    TaskyTheme {
+        RegisterScreen(
+            state = RegisterState(),
+            onAction = {}
+        ) 
+    }
+}

--- a/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterState.kt
+++ b/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterState.kt
@@ -1,0 +1,14 @@
+package com.jvoye.tasky.auth.presentation.register
+
+import androidx.compose.foundation.text.input.TextFieldState
+import com.jvoye.tasky.auth.domain.PasswordValidationState
+
+data class RegisterState(
+    val name: TextFieldState = TextFieldState(),
+    val email: TextFieldState = TextFieldState(),
+    val isNameValid: Boolean = true,
+    val isEmailValid: Boolean = true,
+    val password: TextFieldState = TextFieldState(),
+    val isPasswordVisible: Boolean = false,
+    val passwordValidationState: PasswordValidationState = PasswordValidationState()
+)

--- a/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/jvoye/tasky/auth/presentation/register/RegisterViewModel.kt
@@ -1,0 +1,28 @@
+package com.jvoye.tasky.auth.presentation.register
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class RegisterViewModel: ViewModel() {
+
+    private val _state = MutableStateFlow(RegisterState())
+    val state = _state.asStateFlow()
+
+    fun onAction(action: RegisterAction) {
+        when(action) {
+            RegisterAction.OnLoginClick -> {
+
+            }
+            RegisterAction.OnTogglePasswordVisibilityClick -> {
+                _state.update { it.copy(
+                    isPasswordVisible = !it.isPasswordVisible
+                )}
+            }
+            RegisterAction.OnGetStartedClick -> {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/buttons/TaskyDeleteButton.kt
+++ b/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/buttons/TaskyDeleteButton.kt
@@ -3,10 +3,8 @@ package com.jvoye.tasky.core.presentation.designsystem.buttons
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/buttons/TaskyFilledButton.kt
+++ b/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/buttons/TaskyFilledButton.kt
@@ -3,10 +3,8 @@ package com.jvoye.tasky.core.presentation.designsystem.buttons
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button

--- a/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/textfields/TaskyPasswordTextField.kt
+++ b/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/textfields/TaskyPasswordTextField.kt
@@ -1,0 +1,152 @@
+package com.jvoye.tasky.core.presentation.designsystem.textfields
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicSecureTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.TextObfuscationMode
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.jvoye.tasky.R
+import com.jvoye.tasky.core.presentation.designsystem.theme.Icon_Eye_Closed
+import com.jvoye.tasky.core.presentation.designsystem.theme.Icon_Eye_Open
+import com.jvoye.tasky.core.presentation.designsystem.theme.TaskyTheme
+import com.jvoye.tasky.core.presentation.designsystem.theme.surfaceHigher
+
+@Composable
+fun TaskyPasswordTextField(
+    state: TextFieldState,
+    isPasswordVisible: Boolean,
+    onTogglePasswordVisibility: () -> Unit,
+    hint: String,
+    modifier: Modifier = Modifier
+) {
+    var isFocused by remember {
+        mutableStateOf(false)
+    }
+
+    BasicSecureTextField(
+        state = state,
+        textObfuscationMode = if (isPasswordVisible) {
+            TextObfuscationMode.Visible
+        } else {
+            TextObfuscationMode.Hidden
+        },
+        textStyle = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onSurface
+        ),
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Password
+        ),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(
+                MaterialTheme.colorScheme.surfaceHigher
+            )
+            .border(
+                width = 1.dp,
+                color = if (isFocused){
+                    MaterialTheme.colorScheme.outline
+                } else {
+                    Color.Transparent
+                },
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(start = 20.dp, top = 10.dp, end = 6.dp, bottom = 10.dp)
+            .onFocusChanged {
+                isFocused = it.isFocused
+            },
+        decorator = { innerBox ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                ) {
+                    if (state.text.isEmpty() && !isFocused) {
+                        Text(
+                            text = hint,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                alpha = 0.7f
+                            ),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    innerBox()
+                }
+                IconButton(
+                    onClick = onTogglePasswordVisibility
+                ) {
+                    Icon(
+                        imageVector = if(!isPasswordVisible) {
+                            Icon_Eye_Closed
+                        } else {
+                            Icon_Eye_Open
+                        },
+                        contentDescription = if(isPasswordVisible) {
+                            stringResource(R.string.show_password)
+                        } else {
+                            stringResource(R.string.hide_password)
+                        },
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                            alpha = 0.7f)
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Preview (showSystemUi = true)
+@Composable
+private fun TaskyPasswordTextFieldPreview() {
+    TaskyTheme {
+        Column (
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TaskyPasswordTextField(
+                state = rememberTextFieldState(),
+                hint = stringResource(R.string.password),
+                modifier = Modifier
+                    .fillMaxWidth(),
+                isPasswordVisible = false,
+                onTogglePasswordVisibility = {}
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/textfields/TaskyTextField.kt
+++ b/app/src/main/java/com/jvoye/tasky/core/presentation/designsystem/textfields/TaskyTextField.kt
@@ -1,0 +1,140 @@
+package com.jvoye.tasky.core.presentation.designsystem.textfields
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.jvoye.tasky.core.presentation.designsystem.theme.Icon_Check
+import com.jvoye.tasky.core.presentation.designsystem.theme.TaskyTheme
+import com.jvoye.tasky.core.presentation.designsystem.theme.success
+import com.jvoye.tasky.core.presentation.designsystem.theme.surfaceHigher
+
+@Composable
+fun TaskyTextField(
+    state: TextFieldState,
+    endIcon: ImageVector?,
+    borderColor: Color,
+    hint: String,
+    modifier: Modifier = Modifier,
+    keyboardType: KeyboardType = KeyboardType.Text
+) {
+    var isFocused by remember {
+        mutableStateOf(false)
+    }
+
+    BasicTextField(
+        state = state,
+        textStyle = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onSurface
+        ),
+        keyboardOptions = KeyboardOptions(
+            keyboardType = keyboardType
+        ),
+        lineLimits = TextFieldLineLimits.SingleLine,
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(
+                MaterialTheme.colorScheme.surfaceHigher
+            )
+            .border(
+                width = 1.dp,
+                color = if (isFocused) {
+                    MaterialTheme.colorScheme.outline
+                } else {
+                    borderColor
+                },
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(20.dp)
+            .onFocusChanged {
+                isFocused = it.isFocused
+            },
+        decorator = { innerBox ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                ) {
+                    if (state.text.isEmpty() && !isFocused) {
+                        Text(
+                            text = hint,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                alpha = 0.7f
+                            ),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(20.dp))
+
+                if (endIcon != null){
+                    Icon(
+                        imageVector = endIcon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.success
+                    )
+                }
+            }
+            innerBox()
+        }
+    )
+}
+
+@Preview (showSystemUi = true)
+@Composable
+private fun TaskyTextFieldPreview() {
+    TaskyTheme {
+        Column (
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TaskyTextField(
+                state = rememberTextFieldState(),
+                endIcon = Icon_Check,
+                hint = "email@test.com",
+                borderColor = MaterialTheme.colorScheme.surfaceHigher,
+                modifier = Modifier
+                    .fillMaxWidth()
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,12 @@
     <string name="cancel">CANCEL</string>
     <string name="delete">DELETE</string>
     <string name="plus_icon">Plus Icon</string>
+    <string name="email_address">Email address</string>
+    <string name="show_password">Show password</string>
+    <string name="hide_password">Hide password</string>
+    <string name="password">Password</string>
+    <string name="create_your_account">Create your account</string>
+    <string name="name">Name</string>
+    <string name="already_have_an_account">ALREADY HAVE AN ACCOUNT?</string>
+    <string name="login">LOG IN</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ nav3Core = "1.0.0-alpha05"
 nav3Lifecycle = "1.0.0-alpha03"
 material3Adaptive = "1.1.2"
 windowsizeclass = "1.3.2"
+composeFoundation = "1.8.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -37,7 +38,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "composeFoundation" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref="splashscreen"}
 
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
Adding RegisterScreen without user input validation. This is rather a larger commit, to make the TextFields within the RegisterScreen interactive. User validation of name, email and password is not implemented yet.